### PR TITLE
Fixed issue with haplotypcalling. Added '\'

### DIFF
--- a/modules/local/haplotypecaller/main.nf
+++ b/modules/local/haplotypecaller/main.nf
@@ -15,7 +15,7 @@ process HAPLOTYPECALLER {
 
 	script: 
 	"""
-	gatk HaplotypeCaller 
+	gatk HaplotypeCaller \
 	-R ${reference_genome} \
 	-I ${marked_bam} \
 	-O ${sampleId}.g.vcf \


### PR DESCRIPTION
Haplotypecalling failed due to not escaping the line correcting 